### PR TITLE
Unset problematic environment variables in tests

### DIFF
--- a/t/test.sh
+++ b/t/test.sh
@@ -463,6 +463,8 @@ fi
 WVSTART "compression"
 D=compression0.tmp
 export BUP_DIR="$TOP/$D/.bup"
+# environment variables affect du output & break tests
+export -n BLOCKSIZE BLOCK_SIZE DU_BLOCK_SIZE
 rm -rf $D
 mkdir $D
 WVPASS bup init


### PR DESCRIPTION
Certain environment variables affect the output of 'du' and break
the tests. Therefore, unset the folowing:
- BLOCKSIZE
- DU_BLOCK_SIZE
- BLOCK_SIZE

Signed-off-by: Michael Ekstrand michael@elehack.net
