### PR TITLE
Makefile: respect system cflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 OS:=$(shell uname | sed 's/[-_].*//')
-CFLAGS:=-Wall -O2 -Werror $(PYINCLUDE)
+CFLAGS ?= -O2 -Werror
+CFLAGS += -Wall $(PYINCLUDE)
 SOEXT:=.so
 
 ifeq ($(OS),CYGWIN)


### PR DESCRIPTION
In case a user has set his own CFLAGS, then your Makefile will still ignore/overwrite them. This commit fixes it.

-Wall and the python stuff however is appended to CFLAGS unconditionally
