### PR TITLE
Add 'tag -f' support

### DIFF
--- a/Documentation/bup-tag.md
+++ b/Documentation/bup-tag.md
@@ -10,9 +10,9 @@ bup-tag - tag a commit in the bup repository
 
 bup tag
 
-bup tag \<tag name\> \<committish\>
+bup tag [-f] \<tag name\> \<committish\>
 
-bup tag -d \<tag name\>
+bup tag [-f] -d \<tag name\>
 
 # DESCRIPTION
 
@@ -42,6 +42,9 @@ through /.tag/important as long as the tag is not deleted.
 
 -d, \--delete
 :   delete a tag
+
+-f, \--force
+:   Overwrite the named tag even if it already exists. With -d, don't report a missing tag as an error.
 
 # EXAMPLE
     

--- a/cmd/tag-cmd.py
+++ b/cmd/tag-cmd.py
@@ -14,10 +14,11 @@ handle_ctrl_c()
 
 optspec = """
 bup tag
-bup tag <tag name> <commit>
-bup tag -d <tag name>
+bup tag [-f] <tag name> <commit>
+bup tag [-f] -d <tag name>
 --
 d,delete=   Delete a tag
+f,force     Overwrite existing tag, or 'delete' a tag that doesn't exist
 """
 
 o = options.Options(optspec)
@@ -29,6 +30,8 @@ if opt.delete:
     tag_file = git.repo('refs/tags/%s' % opt.delete)
     debug1("tag file: %s\n" % tag_file)
     if not os.path.exists(tag_file):
+        if opt.force:
+            sys.exit(0)
         log("bup: error: tag '%s' not found.\n" % opt.delete)
         sys.exit(1)
 
@@ -54,7 +57,7 @@ if not tag_name:
     o.fatal("tag name must not be empty.")
 debug1("args: tag name = %s; commit = %s\n" % (tag_name, commit))
 
-if tag_name in tags:
+if tag_name in tags and not opt.force:
     log("bup: error: tag '%s' already exists\n" % tag_name)
     sys.exit(1)
 

--- a/t/test.sh
+++ b/t/test.sh
@@ -297,7 +297,11 @@ WVFAIL bup tag v0.n non-existant 2>/dev/null
 WVPASSEQ "$(bup tag)" ""
 WVPASS bup tag v0.1 master
 WVPASSEQ "$(bup tag)" "v0.1"
+WVFAIL bup tag v0.1 master
+WVPASS bup tag -f v0.1 master
 WVPASS bup tag -d v0.1
+WVPASS bup tag -f -d v0.1
+WVFAIL bup tag -d v0.1
 
 # This section destroys data in the bup repository, so it is done last.
 WVSTART "fsck"


### PR DESCRIPTION
Lets you use 'bup tag -f name commit' to overwrite an existing tag without confirmation, and 'bup tag -d -f tag' to successfully "delete" a tag even if it doesn't exist.
