### PR TITLE
Added sleep 0.1 to wait for the previous process to fully finish else umount will fail with busy file system on some systems.

### DIFF
--- a/t/test-index-check-device.sh
+++ b/t/test-index-check-device.sh
@@ -42,7 +42,7 @@ WVPASS chown root:root "$tmpmnt1"
 WVPASS chmod 0700 "$tmpmnt1"
 
 # Create trivial content.
-WVPASS date > "$tmpmnt1/foo"
+WVPASS date > "$tmpmnt1/foo" && sleep 0.1
 WVPASS umount "$tmpmnt1"
 
 # Mount twice, so we'll have the same content with different devices.


### PR DESCRIPTION
! t/test-index-check-device.sh:38  mke2fs -F -j -m 0 testfs.img     ok
! t/test-index-check-device.sh:39  mount -o loop testfs.img /opt/bup/t/mnt/test-index-check-device.sh-YuNQZtU ok
! t/test-index-check-device.sh:41  chown root:root /opt/bup/t/mnt/test-index-check-device.sh-YuNQZtU ok
! t/test-index-check-device.sh:42  chmod 0700 /opt/bup/t/mnt/test-index-check-device.sh-YuNQZtU ok
! t/test-index-check-device.sh:45  date                             ok
umount: /opt/bup/t/mnt/test-index-check-device.sh-YuNQZtU: device is busy.
        (In some cases useful info about processes that use
         the device is found by lsof(8) or fuser(1))
! t/test-index-check-device.sh:46  umount /opt/bup/t/mnt/test-index-check-device.sh-YuNQZtU FAILED
