### PR TITLE
web: Fix unescaped link

### DIFF
--- a/lib/web/list-directory.html
+++ b/lib/web/list-directory.html
@@ -29,7 +29,7 @@
                 </tr>
                 {% for (display, link, size) in dir_contents %}
                 <tr>
-                    <td class="dir-name"><a href="{{ link }}">{{ display }}</a></td>
+                    <td class="dir-name"><a href="{{ url_escape(link) }}">{{ display }}</a></td>
                     <td class="dir-size">{% if size != None %}{{ size }}{% else %}&nbsp;{% end %}</td>
                 </tr>
                 {% end %}


### PR DESCRIPTION
Example of how to trigger the issue:

```
mkdir -p example/github.com:443
bup index example
bup save --name example example
bup web &
sleep 1
firefox "http://127.0.0.1:8080/example/latest/`pwd`/example/"
# Click the "github.com:443" directory link in firefox
```

This commit corrects the issue.
