### PR TITLE
Raise Error When the compression_level is invalid

### DIFF
--- a/lib/bup/git.py
+++ b/lib/bup/git.py
@@ -240,9 +240,9 @@ def _encode_packobj(type, content, compression_level=1):
         szbits = sz & 0x7f
         sz >>= 7
     if compression_level > 9:
-        compression_level = 9
+        raise BaseException("Compression Level Above 9")
     elif compression_level < 0:
-        compression_level = 0
+        raise BaseException("Compression Level Below 0")
     z = zlib.compressobj(compression_level)
     yield szout
     yield z.compress(content)


### PR DESCRIPTION
Wouldn't this be better than forcing to a specific compression level? 
Note: I just saw this while glancing through the code, so I may very well be wrong.