### PR TITLE
Allow installation to /usr/share

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,6 +19,12 @@ if os.path.exists("%s/lib/bup/cmd/." % exeprefix):
     cmdpath = "%s/lib/bup/cmd" % exeprefix
     libpath = "%s/lib/bup" % exeprefix
     resourcepath = libpath
+elif os.path.exists("%s/share/bup/cmd/." % exeprefix):
+    # installed binary in /.../share.
+    # eg. /usr/bin/bup means /usr/share/bup/... is where our libraries are.
+    cmdpath = "%s/share/bup/cmd" % exeprefix
+    libpath = "%s/share/bup" % exeprefix
+    resourcepath = libpath
 else:
     # running from the src directory without being installed first
     cmdpath = os.path.join(exepath, 'cmd')


### PR DESCRIPTION
This change allows the bup package files to be installed
into /usr/share/bup. This is nice to comply with
packaging guidelines of some Linux distributions (where
/usr/lib or /usr/lib64 are reserved for platform specific
files whereas platform independent ones are going to be
installed in /usr/share).

Signed-off-by: Martin Höher <martin@rpdev.net>