### PR TITLE
import helpers.add_error

### DIFF
--- a/cmd/bloom-cmd.py
+++ b/cmd/bloom-cmd.py
@@ -8,7 +8,7 @@ exec "$bup_python" "$0" ${1+"$@"}
 import glob, os, sys, tempfile
 
 from bup import options, git, bloom
-from bup.helpers import (debug1, handle_ctrl_c, log, progress, qprogress,
+from bup.helpers import (add_error, debug1, handle_ctrl_c, log, progress, qprogress,
                          saved_errors)
 
 optspec = """

--- a/cmd/index-cmd.py
+++ b/cmd/index-cmd.py
@@ -9,7 +9,7 @@ import sys, stat, time, os, errno, re
 
 from bup import metadata, options, git, index, drecurse, hlinkdb
 from bup.hashsplit import GIT_MODE_TREE, GIT_MODE_FILE
-from bup.helpers import (handle_ctrl_c, log, parse_excludes, parse_rx_excludes,
+from bup.helpers import (add_error, handle_ctrl_c, log, parse_excludes, parse_rx_excludes,
                          progress, qprogress, saved_errors)
 
 

--- a/cmd/list-idx-cmd.py
+++ b/cmd/list-idx-cmd.py
@@ -8,7 +8,7 @@ exec "$bup_python" "$0" ${1+"$@"}
 import sys, os
 
 from bup import git, options
-from bup.helpers import handle_ctrl_c, log, qprogress, saved_errors
+from bup.helpers import add_error, handle_ctrl_c, log, qprogress, saved_errors
 
 
 optspec = """

--- a/cmd/midx-cmd.py
+++ b/cmd/midx-cmd.py
@@ -8,7 +8,7 @@ exec "$bup_python" "$0" ${1+"$@"}
 import glob, math, os, resource, struct, sys, tempfile
 
 from bup import options, git, midx, _helpers, xstat
-from bup.helpers import (Sha1, atomically_replaced_file, debug1, fdatasync,
+from bup.helpers import (Sha1, add_error, atomically_replaced_file, debug1, fdatasync,
                          handle_ctrl_c, log, mmap_readwrite, qprogress,
                          saved_errors, unlink)
 

--- a/cmd/restore-cmd.py
+++ b/cmd/restore-cmd.py
@@ -9,7 +9,7 @@ import copy, errno, os, sys, stat, re
 
 from bup import options, git, metadata, vfs
 from bup._helpers import write_sparsely
-from bup.helpers import (chunkyreader, handle_ctrl_c, log, mkdirp,
+from bup.helpers import (add_error, chunkyreader, handle_ctrl_c, log, mkdirp,
                          parse_rx_excludes, progress, qprogress, saved_errors,
                          should_rx_exclude_path, unlink)
 

--- a/cmd/split-cmd.py
+++ b/cmd/split-cmd.py
@@ -8,7 +8,7 @@ exec "$bup_python" "$0" ${1+"$@"}
 import os, sys, time
 
 from bup import hashsplit, git, options, client
-from bup.helpers import (handle_ctrl_c, log, parse_num, qprogress, reprogress,
+from bup.helpers import (add_error, handle_ctrl_c, log, parse_num, qprogress, reprogress,
                          saved_errors)
 
 

--- a/cmd/xstat-cmd.py
+++ b/cmd/xstat-cmd.py
@@ -10,7 +10,7 @@ exec "$bup_python" "$0" ${1+"$@"}
 # Public License as described in the bup LICENSE file.
 import sys, stat, errno
 from bup import metadata, options, xstat
-from bup.helpers import handle_ctrl_c, parse_timestamp, saved_errors, \
+from bup.helpers import add_error, handle_ctrl_c, parse_timestamp, saved_errors, \
     add_error, log
 
 

--- a/lib/bup/drecurse.py
+++ b/lib/bup/drecurse.py
@@ -1,7 +1,7 @@
 
 import stat, os
 
-from bup.helpers import should_rx_exclude_path, debug1
+from bup.helpers import add_error, should_rx_exclude_path, debug1
 import bup.xstat as xstat
 
 


### PR DESCRIPTION
in the Jan 17 commit, in several command files, "from helpers import *" was changed to "from helpers import TOKENS" but the error handler add_error was inadvertently omitted from the list of specific tokens.
The reason I found this was running "bup restore" with an invalid path. instead of a friendly error telling me the path on the command line was invalid, I got a NameError that add_error is not defined in bup-restore.
grepping for add_error in that directory I found a few files where it was used but not in the imports, so I included those in this pull request. 
Thanks!