### PR TITLE
Fix bup restore --sparse corruption.

### DIFF
--- a/lib/bup/_helpers.c
+++ b/lib/bup/_helpers.c
@@ -318,12 +318,12 @@ static PyObject *bup_write_sparsely(PyObject *self, PyObject *args)
     assert(zeros_read <= unexamined);
     unexamined -= zeros_read;
     if (!uadd(&zeros, prev_sparse_len, zeros_read))
-    {
-        PyObject *err = append_sparse_region(fd, prev_sparse_len);
-        if (err != NULL)
-            return err;
-        zeros = zeros_read;
-    }
+        return PyErr_Format(PyExc_OverflowError, "(prev_sparse_len, zeros_read) too large");
+
+    PyObject *err = append_sparse_region(fd, prev_sparse_len);
+    if (err != NULL)
+        return err;
+    zeros = zeros_read;
 
     while(unexamined)
     {


### PR DESCRIPTION
append_sparse_region() wasn't ever called for the leading zeroes,
which made bup restore --sparse sometimes skip blocks, resulting
in corrupt restores.