### PR TITLE
Fix an error when pandoc is installed in a directory containing spaces.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ define install-python-bin
   chmod 0755 $2;
 endef
 
-PANDOC ?= $(shell type -p pandoc)
+PANDOC ?= "$(shell type -p pandoc)"
 
 ifeq (,$(PANDOC))
   $(shell echo "Warning: pandoc not found; skipping manpage generation" 1>&2)


### PR DESCRIPTION
On 64-bit Cygwin, there is no pandoc package. The native Windows pandoc installs in "C:\Program Files (x86)\Pandoc" by default. This adds quotes around the path to pandoc to accommodate the spaces.
