### PR TITLE
workaround for error in is_superuser on Cygwin

### DIFF
--- a/lib/bup/helpers.py
+++ b/lib/bup/helpers.py
@@ -325,7 +325,7 @@ def detect_fakeroot():
 _warned_about_superuser_detection = None
 def is_superuser():
     if sys.platform.startswith('cygwin'):
-        if sys.getwindowsversion()[0] > 5:
+        if not hasattr(sys, 'getwindowsversion') or sys.getwindowsversion()[0] > 5:
             # Sounds like situation is much more complicated here
             global _warned_about_superuser_detection
             if not _warned_about_superuser_detection:


### PR DESCRIPTION
Just quick workaround, since sys module doesn't have getwindowsversion() function in Python 2.7 on Cygwin.

Perhaps other places should be fixed too, see commit [#461b5b4
](https://github.com/bup/bup/commit/461b5b40baa7639b2cf93483247a21249320a5c5#diff-6b95b6944ace85787cf4f9d2d6c02480)