### PR TITLE
Fix typos

### DIFF
--- a/DESIGN
+++ b/DESIGN
@@ -548,7 +548,7 @@ the index and backs up any file that is "dirty," that is, doesn't already
 exist in the repository.
 
 Determination of dirtiness is a little more complicated than it sounds.  The
-most dirtiness-relevant relevant flag in the bupindex is IX_HASHVALID; if
+most dirtiness-relevant flag in the bupindex is IX_HASHVALID; if
 this flag is reset, the file *definitely* is dirty and needs to be backed
 up.  But a file may be dirty even if IX_HASHVALID is set, and that's the
 confusing part.

--- a/DESIGN
+++ b/DESIGN
@@ -196,7 +196,7 @@ sequence data.
 As an overhead percentage, 0.25% basically doesn't matter.  488 megs sounds
 like a lot, but compared to the 200GB you have to store anyway, it's
 irrelevant.  What *is* relevant is that 488 megs is a lot of memory you have
-to use in order to to keep track of the list.  Worse, if you back up an
+to use in order to keep track of the list.  Worse, if you back up an
 almost-identical file tomorrow, you'll have *another* 488 meg blob to keep
 track of, and it'll be almost but not quite the same as last time.
 
@@ -374,7 +374,7 @@ So that's the basic structure of a bup repository, which is also a git
 repository.  There's just one more thing we have to deal with:
 filesystem metadata.  Git repositories are really only intended to
 store file contents with a small bit of extra information, like
-symlink targets and and executable bits, so we have to store the rest
+symlink targets and executable bits, so we have to store the rest
 some other way.
 
 Bup stores more complete metadata in the VFS in a file named .bupm in

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ this time?  Me neither.
 Despite its unassuming name, bup is pretty cool.  To give you an idea of
 just how cool it is, I wrote you this poem:
 
-                             Bup is teh awesome
+                             Bup is the awesome
                           What rhymes with awesome?
                             I guess maybe possum
                            But that's irrelevant.


### PR DESCRIPTION
The following changes since commit 7641fcf975ad71049e08bfc1482e360790301342:

  test-ls: discover socket mode like symlink mode (2017-03-26 17:21:24 -0500)

are available in the git repository at:

  https://github.com/bedhanger/bup.git fix-typos

for you to fetch changes up to 797f238eec254326d6985d515eb3a4818a0db56d:

  DESIGN: remove surplus ``relevant'' (2017-03-27 18:41:51 +0200)