### PR TITLE
Add missing import "parse_date_or_fatal" to cmd/split-cmd.py

### DIFF
--- a/cmd/split-cmd.py
+++ b/cmd/split-cmd.py
@@ -10,7 +10,8 @@ import os, sys, time
 from bup import hashsplit, git, options, client
 from bup.helpers import (add_error, handle_ctrl_c, hostname, log, parse_num,
                          qprogress, reprogress, saved_errors,
-                         userfullname, username, valid_save_name)
+                         userfullname, username, valid_save_name,
+                         parse_date_or_fatal)
 
 
 optspec = """


### PR DESCRIPTION
If using `bup split -n NAME -d STAMP FILE` we currently get an error:
```python
Traceback (most recent call last):
  File "/usr/lib/bup/cmd/bup-split", line 67, in <module>
    date = parse_date_or_fatal(opt.date, o.fatal)
NameError: name 'parse_date_or_fatal' is not defined
```
this patch does add the missing `parse_date_or_fatal` to `from bup.helpers import`