### PR TITLE
Make os.fsync() failure non-fatal. Needed on mounted CIFS file systems.

### DIFF
--- a/lib/bup/git.py
+++ b/lib/bup/git.py
@@ -812,6 +812,8 @@ class PackWriter:
         os.rename(self.filename + '.idx', nameprefix + '.idx')
         try:
             os.fsync(self.parentfd)
+        except:
+            pass
         finally:
             os.close(self.parentfd)
 


### PR DESCRIPTION
Trying to do `os.fsync()` on a CIFS mounted file system from Linux is not supported. This patch makes the failure non-fatal.
