### PR TITLE
FreeBSD fix for "printf: missing format character"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ lib/bup/_helpers$(SOEXT): \
 	LDFLAGS="$(LDFLAGS)" CFLAGS="$(CFLAGS)" "$(bup_python)" csetup.py build
         # Make sure there's just the one file we expect before we copy it.
 	find lib/bup/build/* -maxdepth 1 -name '_helpers*$(SOEXT)' \
-	  -exec printf 'x' '{}' \; | wc -c | xargs test 1 -eq
+	  | wc -l | xargs test 1 -eq
 	cp lib/bup/build/*/_helpers*$(SOEXT) "$@"
 
 lib/bup/_checkout.py:


### PR DESCRIPTION
FreeBSD 11.1-RELEASE throws an error on this invocation.
Since we're already using wc(1), we might as well just use
the -l option here.