### PR TITLE
Performance improvements on distributed file systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ From source
             apt-get install python-pyxattr python-pylibacl
             apt-get install linux-libc-dev
             apt-get install acl attr
+            apt-get install python-scandir # optional, improves performance
             apt-get install python-tornado # optional
 
    On CentOS (for CentOS 6, at least), this should be sufficient (run
@@ -135,12 +136,18 @@ From source
             yum groupinstall "Development Tools"
             yum install python python-devel
             yum install fuse-python pyxattr pylibacl
+            yum install python-scandir # optional, improves performance
             yum install perl-Time-HiRes
 
    In addition to the default CentOS repositories, you may need to add
    RPMForge (for fuse-python) and EPEL (for pyxattr and pylibacl).
 
    On Cygwin, install python, make, rsync, and gcc4.
+
+   If you would like to have optional on system without a python-scandir
+   package, you may want to try this:
+
+            pip install scandir
 
    If you would like to use the optional bup web server on systems
    without a tornado package, you may want to try this:

--- a/cmd/index-cmd.py
+++ b/cmd/index-cmd.py
@@ -12,7 +12,7 @@ from bup import metadata, options, git, index, drecurse, hlinkdb
 from bup.drecurse import recursive_dirlist
 from bup.hashsplit import GIT_MODE_TREE, GIT_MODE_FILE
 from bup.helpers import (add_error, handle_ctrl_c, log, parse_excludes, parse_rx_excludes,
-                         progress, qprogress, saved_errors)
+                         progress, qprogress, saved_errors, INO_FIX)
 
 
 class IterHelper:
@@ -129,7 +129,7 @@ def update_index(top, excluded_paths, exclude_rxs, xdev_exceptions):
                 if not stat.S_ISDIR(rig.cur.mode) and rig.cur.nlink > 1:
                     hlinks.del_path(rig.cur.name)
                 if not stat.S_ISDIR(pst.st_mode) and pst.st_nlink > 1:
-                    hlinks.add_path(path, pst.st_dev, pst.st_ino)
+                    hlinks.add_path(path, pst.st_dev, pst.st_ino & INO_FIX)
                 # Clear these so they don't bloat the store -- they're
                 # already in the index (since they vary a lot and they're
                 # fixed length).  If you've noticed "tmax", you might
@@ -172,7 +172,7 @@ def update_index(top, excluded_paths, exclude_rxs, xdev_exceptions):
             meta_ofs = msw.store(meta)
             wi.add(path, pst, meta_ofs, hashgen=fake_hash)
             if not stat.S_ISDIR(pst.st_mode) and pst.st_nlink > 1:
-                hlinks.add_path(path, pst.st_dev, pst.st_ino)
+                hlinks.add_path(path, pst.st_dev, pst.st_ino & INO_FIX)
 
     elapsed = time.time() - index_start
     paths_per_sec = total / elapsed if elapsed else 0

--- a/cmd/index-cmd.py
+++ b/cmd/index-cmd.py
@@ -118,7 +118,10 @@ def update_index(top, excluded_paths, exclude_rxs, xdev_exceptions):
             need_repack = False
             if(rig.cur.stale(pst, tstart, check_device=opt.check_device)):
                 try:
-                    meta = metadata.from_path(path, statinfo=pst)
+                    meta = metadata.from_path(
+                        path,
+                        statinfo=pst,
+                        no_nonstat_metadata=opt.no_nonstat_metadata)
                 except (OSError, IOError) as e:
                     add_error(e)
                     rig.next()
@@ -157,7 +160,10 @@ def update_index(top, excluded_paths, exclude_rxs, xdev_exceptions):
             rig.next()
         else:  # new paths
             try:
-                meta = metadata.from_path(path, statinfo=pst)
+                meta = metadata.from_path(
+                    path,
+                    statinfo=pst,
+                    no_nonstat_metadata=opt.no_nonstat_metadata)
             except (OSError, IOError) as e:
                 add_error(e)
                 continue
@@ -215,6 +221,7 @@ clear      clear the default index
 H,hash     print the hash for each object next to its name
 l,long     print more information about each file
 no-check-device don't invalidate an entry if the containing device changes
+no-nonstat-metadata skip indexing metadata beyond stat() (xattrs, ACLs)
 fake-valid mark all index entries as up-to-date even if they aren't
 fake-invalid mark all index entries as invalid
 f,indexfile=  the name of the index file (normally BUP_DIR/bupindex)

--- a/lib/bup/drecurse.py
+++ b/lib/bup/drecurse.py
@@ -2,9 +2,17 @@
 from __future__ import absolute_import
 import stat, os
 
-from bup.helpers import add_error, should_rx_exclude_path, debug1, resolve_parent
+from bup.helpers import add_error, should_rx_exclude_path, debug1, resolve_parent, log
 import bup.xstat as xstat
 
+scandir = None
+try:
+    # scandir allows much faster directory traversals, but is
+    # only included in the stanard library from Python 3.3 upwards.
+    import scandir
+except ImportError:
+    log('Warning: scandir support missing; install python-scandir'
+        ' to speed up directory traversals.\n')
 
 try:
     O_LARGEFILE = os.O_LARGEFILE
@@ -37,15 +45,37 @@ class OsFile:
         return xstat.fstat(self.fd)
 
 
+def _filename_stat_generator(path):
+    """Yields all file entry names (not prefixed with path) and their
+    stat info; stat errors are skipped over with add_error().
+
+    Uses a fast/streaming, scandir based traversal when scandir is available.
+    """
+    if scandir is not None:
+        for entry in scandir.scandir(path):
+            n = entry.name
+            try:
+                # We need to use xstat instead of entry.stat() because
+                # entry.stat() uses Python's normal floating-point mtimes.
+                st = xstat.lstat(n)
+                yield (n,st)
+            except OSError as e:
+                add_error(Exception('%s: %s' % (resolve_parent(n), str(e))))
+                continue
+    else:
+        for n in os.listdir(path):
+            try:
+                st = xstat.lstat(n)
+                yield (n,st)
+            except OSError as e:
+                add_error(Exception('%s: %s' % (resolve_parent(n), str(e))))
+                continue
+
+
 _IFMT = stat.S_IFMT(0xffffffff)  # avoid function call in inner loop
 def _dirlist():
     l = []
-    for n in os.listdir('.'):
-        try:
-            st = xstat.lstat(n)
-        except OSError as e:
-            add_error(Exception('%s: %s' % (resolve_parent(n), str(e))))
-            continue
+    for (n,st) in _filename_stat_generator('.'):
         if (st.st_mode & _IFMT) == stat.S_IFDIR:
             n += '/'
         l.append((n,st))

--- a/lib/bup/helpers.py
+++ b/lib/bup/helpers.py
@@ -1210,3 +1210,12 @@ def period_as_secs(s):
                   'w': 60 * 60 * 24 * 7,
                   'm': 60 * 60 * 24 * 31,
                   'y': 60 * 60 * 24 * 366}[scale]
+
+# Used to work around st_ino incorrectly being signed instead of unsigned
+# in Python < 3.6:
+#   https://bugs.python.org/issue29619
+#   https://github.com/python/cpython/commit/0f6d73343d342c106cda2219ebb8a6f0c4bd9b3c
+#
+# To work around it, any `st_ino` as obtained from `os.stat()`
+# should be cast to unsigned using `thestat.st_ino & INO_FIX`.
+INO_FIX = sys.maxsize * 2 + 1  # 0b11...11 for this architecture

--- a/lib/bup/index.py
+++ b/lib/bup/index.py
@@ -5,7 +5,8 @@ import errno, os, stat, struct, tempfile
 from bup import metadata, xstat
 from bup._helpers import UINT_MAX, bytescmp
 from bup.helpers import (add_error, log, merge_iter, mmap_readwrite,
-                         progress, qprogress, resolve_parent, slashappend)
+                         progress, qprogress, resolve_parent, slashappend,
+                         INO_FIX)
 
 EMPTY_SHA = '\0'*20
 FAKE_SHA = '\x01'*20
@@ -208,7 +209,7 @@ class Entry:
             return True
         if self.ctime != st.st_ctime:
             return True
-        if self.ino != st.st_ino:
+        if self.ino != (st.st_ino & INO_FIX):
             return True
         if self.nlink != st.st_nlink:
             return True
@@ -226,7 +227,7 @@ class Entry:
         # Should only be called when the entry is stale(), and
         # invalidate() should almost certainly be called afterward.
         self.dev = st.st_dev
-        self.ino = st.st_ino
+        self.ino = st.st_ino & INO_FIX
         self.nlink = st.st_nlink
         self.ctime = st.st_ctime
         self.mtime = st.st_mtime
@@ -579,7 +580,7 @@ class Writer:
             isdir = stat.S_ISDIR(st.st_mode)
             assert(isdir == endswith)
             e = NewEntry(basename, name, self.tmax,
-                         st.st_dev, st.st_ino, st.st_nlink,
+                         st.st_dev, st.st_ino & INO_FIX, st.st_nlink,
                          st.st_ctime, st.st_mtime, st.st_atime,
                          st.st_size, st.st_mode, gitmode, sha, flags,
                          meta_ofs, 0, 0)

--- a/lib/bup/metadata.py
+++ b/lib/bup/metadata.py
@@ -889,7 +889,8 @@ class Metadata:
 
 
 def from_path(path, statinfo=None, archive_path=None,
-              save_symlinks=True, hardlink_target=None):
+              save_symlinks=True, hardlink_target=None,
+              no_nonstat_metadata=False):
     result = Metadata()
     result.path = archive_path
     st = statinfo or xstat.lstat(path)
@@ -898,9 +899,10 @@ def from_path(path, statinfo=None, archive_path=None,
     if save_symlinks:
         result._add_symlink_target(path, st)
     result._add_hardlink_target(hardlink_target)
-    result._add_posix1e_acl(path, st)
-    result._add_linux_attr(path, st)
-    result._add_linux_xattr(path, st)
+    if not no_nonstat_metadata:
+        result._add_posix1e_acl(path, st)
+        result._add_linux_attr(path, st)
+        result._add_linux_xattr(path, st)
     return result
 
 

--- a/lib/bup/xstat.py
+++ b/lib/bup/xstat.py
@@ -123,8 +123,8 @@ def stat(path):
     return stat_result.from_xstat_rep(_helpers.stat(path))
 
 
-def fstat(path):
-    return stat_result.from_xstat_rep(_helpers.fstat(path))
+def fstat(fd):
+    return stat_result.from_xstat_rep(_helpers.fstat(fd))
 
 
 def lstat(path):

--- a/lib/bup/xstat.py
+++ b/lib/bup/xstat.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import os, sys
 import stat as pystat
 from bup import _helpers
+from bup.helpers import INO_FIX
 
 try:
     _bup_utimensat = _helpers.bup_utimensat
@@ -107,6 +108,7 @@ class stat_result:
          result.st_atime,
          result.st_mtime,
          result.st_ctime) = st
+        result.st_ino &= INO_FIX
         # Inlined timespec_to_nsecs after profiling
         result.st_atime = result.st_atime[0] * 10**9 + result.st_atime[1]
         result.st_mtime = result.st_mtime[0] * 10**9 + result.st_mtime[1]

--- a/t/hardlink-sets
+++ b/t/hardlink-sets
@@ -23,6 +23,9 @@ if len(sys.argv) < 2:
 def on_walk_error(e):
     raise e
 
+# See helpers.py for an explanation
+INO_FIX = sys.maxsize * 2 + 1  # 0b11...11 for this architecture
+
 hardlink_set = {}
 
 for p in sys.argv[1:]:
@@ -31,7 +34,7 @@ for p in sys.argv[1:]:
           full_path = os.path.join(root, filename)
           st = os.lstat(full_path)
           if not stat.S_ISDIR(st.st_mode):
-              node = '%s:%s' % (st.st_dev, st.st_ino)
+              node = '%s:%s' % (st.st_dev, st.st_ino & INO_FIX)
               link_paths = hardlink_set.get(node)
               if link_paths:
                   link_paths.append(full_path)


### PR DESCRIPTION
Here are 4 patches that I've been using in the past 8 months to dramatically speed up bup when run against a distributed file system like GlusterFS (and actually makes it possible to use it in such scenarios).

I've shortly discussed them on the bup IRC channel in the past.

Please see the commit descriptions for details.

The use of `scandir` and the fix for `st_ino` are reasonably well tested (over thousands of bup runs), the `no-nonstat-metadata` flag has not been tested as extensively.

---

One question:

Right now, when I run `make test` on Ubuntu 16.04, it fails with:

```
/home/niklas/src/bup/bup ftp
Warning: scandir support missing; install python-scandir to speed up directory traversals.
Makefile:197: recipe for target 'tmp-target-run-test-ftp' failed
make[1]: *** [tmp-target-run-test-ftp] Error 1
make[1]: Leaving directory '/home/niklas/src/bup'
! Program returned non-zero exit code (2)                           FAILED
WvTest: result code 2, total time 17.455s
./wvtest report t/tmp/test-log/*.log

/home/niklas/src/bup/bup ftp
Warning: scandir support missing; install python-scandir to speed up directory traversals.
Commands: ls cd pwd cat get mget help quit
! test-ftp:63   'Commands: ls cd pwd cat get mget help quit\n' == 'Warning: scandir support missing; install python-scandir to speed up directory traversals.\nCommands: ls cd pwd cat get mget help quit\n' FAILED

! Program returned non-zero exit code (2)                           FAILED
```

This is because I'm emitting the `Warning: scandir support missing; install python-scandir to speed up directory traversals` when scandir couldn't be found. I think having this warning is good because scandir really helps a huge deal with performance.

But Ubuntu 16.04 doesn't have `python-scandir` available, only >= 17.10 has it.

(How) should I modify the two failing tests so that they ignore if this warning is emitted?

Thanks!