### PR TITLE
bup save: Make -n <name> mandatory

### DIFF
--- a/cmd/save-cmd.py
+++ b/cmd/save-cmd.py
@@ -21,7 +21,7 @@ from bup.pwdgrp import userfullname, username
 
 
 optspec = """
-bup save [-tc] [-n name] <filenames...>
+bup save [-tc] -n <name> <filenames...>
 --
 r,remote=  hostname:/path/to/repo of remote repository
 t,tree     output a tree id


### PR DESCRIPTION
This commit clarifies the `bup save` command's help message, by specifying that the `-n <name>` argument is mandatory. As of 0.30, it is flagged as optional (`[-n name]`).

Signed-off-by: Adrien Burgun <adrien.burgun@orange.fr>