### PR TITLE
cmd/fsck-cmd.py: Do not warn about empty par2 error output; fix formatting

### DIFF
--- a/cmd/fsck-cmd.py
+++ b/cmd/fsck-cmd.py
@@ -61,7 +61,7 @@ def is_par2_parallel():
         _, err = p.communicate()
         parallel = p.returncode == 0
         if opt.verbose:
-            if err != b'Invalid option specified: -t1\n':
+            if len(err) > 0 and err != b'Invalid option specified: -t1\n':
                 log('Unexpected par2 error output\n')
                 log(repr(err))
             if parallel:

--- a/cmd/fsck-cmd.py
+++ b/cmd/fsck-cmd.py
@@ -63,7 +63,7 @@ def is_par2_parallel():
         if opt.verbose:
             if len(err) > 0 and err != b'Invalid option specified: -t1\n':
                 log('Unexpected par2 error output\n')
-                log(repr(err))
+                log(repr(err) + '\n')
             if parallel:
                 log('Assuming par2 supports parallel processing\n')
             else:


### PR DESCRIPTION
With a recent `par2` installed, `bup fsck -v` outputs messages like

~~~
Unexpected par2 error output
''Assuming par2 supports parallel processing
~~~
and so on. There are obvious issues:

* An empty error output (and exit status 0) of `par2` is needlessly warned about.
* The `Assuming` part immediately follows the quoted error output (empty here).

The fix proposed here suppresses the warning if the stderr output of the test command is empty.
Furthermore it appends a newline to the quoted error output.

One could be more precise and expect an empty string if the `par2` exit status is zero, else expect the `Invalid option` message. And one could question whether testing for informal messages is a reasonable approach at all. But all this only affects `-v` output, so the current proposal is good enough for me.

With this patch, `bup fsck -v` now simply reports

~~~
Assuming par2 supports parallel processing
~~~

which is much cleaner.
