### PR TITLE
Fix bup-web error formatting when port unsupplied

### DIFF
--- a/cmd/web-cmd.py
+++ b/cmd/web-cmd.py
@@ -269,7 +269,7 @@ else:
         try:
             port = int(port)
         except (TypeError, ValueError) as ex:
-            o.fatal('port must be an integer, not %r', port)
+            o.fatal('port must be an integer, not %r' % port)
         address = InetAddress(host=host, port=port)
 
 git.check_repo_or_die()


### PR DESCRIPTION
Previously supplying the bup dir to bup web by mistake would result in a
python syntax error.

Signed-off-by: Wyatt Alt <wyatt.alt@gmail.com>