### PR TITLE
change mktemp to be compatible with busybox

### DIFF
--- a/config/configure.inc
+++ b/config/configure.inc
@@ -594,7 +594,7 @@ MF_PATH_INCLUDE () {
 # and fd 5 points to what used to be fd 1
 #
 AC_INIT () {
-    __ac_tmpdir=$(mktemp -d configure-XXXXX)
+    __ac_tmpdir=$(mktemp -d configure-XXXXXX)
     __config_files="config.cmd config.sub config.h config.mak config.log"
     __config_detritus="config.h.tmp"
     rm -f $__config_files $__config_detritus


### PR DESCRIPTION
Signed-off-by: Brian Minton <brian@minton.name>

This is a trivial change to allow the configure script to work under busybox, which assumes the template argument to end in XXXXXX.