### PR TITLE
git/packwriter: open(..) prohibited in __del__

### DIFF
--- a/lib/bup/git.py
+++ b/lib/bup/git.py
@@ -718,9 +718,6 @@ class PackWriter:
         self.max_pack_objects = max_pack_objects if max_pack_objects \
                                 else max(1, self.max_pack_size // 5000)
 
-    def __del__(self):
-        self.close()
-
     def __enter__(self):
         return self
 


### PR DESCRIPTION
When an exception occurs, `__del__` is invoked by the interpretor, to perform cleanup. It seems that since Python 3.4, the behaviour has changed, and also prohibits invocations of open(..) (source: https://stackoverflow.com/a/29737870). Instead, contextmanager API should be used (source: https://stackoverflow.com/a/26544629), which seems to be in place already.

This should fix exception messages such as 'NameError: name 'open' is not defined'.