### PR TITLE
Set LANGUAGE=en in t/test.sh since it depends on environment

### DIFF
--- a/t/test.sh
+++ b/t/test.sh
@@ -8,6 +8,7 @@ set -o pipefail
 top="$(WVPASS pwd)" || exit $?
 tmpdir="$(WVPASS wvmktempdir)" || exit $?
 export BUP_DIR="$tmpdir/bup"
+export LANGUAGE=en
 
 bup() { "$top/bup" "$@"; }
 


### PR DESCRIPTION
Set LANGUAGE=en in t/test.sh since it depends on environment and fails otherwise.

I experience test failures on Ubuntu 20.04 configure with German as primary language. The test clearly parses output in English and since adapting the parsing to the language of the test environment is not what the test tests, specifying the language is the way to go.