### PR TITLE
wchar_t

### DIFF
--- a/lib/bup/_helpers.c
+++ b/lib/bup/_helpers.c
@@ -356,7 +356,7 @@ static void unpythonize_argv(void) { }
 #else // not __WIN32__
 
 // For some reason this isn't declared in Python.h
-extern void Py_GetArgcArgv(int *argc, char ***argv);
+extern void Py_GetArgcArgv(int *argc, wchar_t ***argv);
 
 static void unpythonize_argv(void)
 {


### PR DESCRIPTION
Compilation of bup with Python 3.9.0 fails on macOS, because the prototype of `Py_GetArgcArgv` in Python 3 is invalid. See https://docs.python.org/fr/3.10/c-api/init_config.html#py-getargcargv
It should be: `void Py_GetArgcArgv(int *argc, wchar_t ***argv)`

This prevents Homebrew from shipping bup with Python 3: https://github.com/Homebrew/homebrew-core/pull/62587

This pull request is not sufficient in itself, because the code below needs to be adapted to deal with wide char variables (wcslen instead of strlen, wcsstr instead of strstr, etc).

PS: If you want to keep supporting Python 2, then two versions need to be introduced, like this:

```
#if PY_MAJOR_VERSION < 3
void Py_GetArgcArgv(int*, char***);
#else
void Py_GetArgcArgv(int*, wchar_t***);
#endif
```

