### PR TITLE
Allow non ASCII chars in files/dirs

### DIFF
--- a/lib/bup/helpers.py
+++ b/lib/bup/helpers.py
@@ -151,7 +151,7 @@ def log(s):
     """Print a log message to stderr."""
     global _last_prog
     sys.stdout.flush()
-    _hard_write(sys.stderr.fileno(), s if isinstance(s, bytes) else s.encode())
+    _hard_write(sys.stderr.fileno(), s if isinstance(s, bytes) else s.encode('utf-8'))
     _last_prog = 0
 
 

--- a/lib/bup/io.py
+++ b/lib/bup/io.py
@@ -11,7 +11,7 @@ if compat.py_maj > 2:
     def path_msg(x):
         """Return a string representation of a path."""
         # FIXME: configurability (might git-config quotePath be involved?)
-        return x.decode(errors='backslashreplace')
+        return x.decode('utf-8', errors='backslashreplace')
 else:
     def byte_stream(file):
         return file


### PR DESCRIPTION
Include support for non-ASCII chars.

Steps to reproduce:
Have a file with non-ASCII chars, like `acción.txt` and try to backup

Current behavior:
Throws: `TypeError: don't know how to handle UnicodeDecodeError in error callback`

Expected behavior:
Backup all files no matter encoding.

WARNING:
The solution that i propose is not well tested, this may cause some weird behavior, only tested with:

`bup -d /Backups save -n kup -vv /home`


Signed-off-by: AfroMonkey <moisalejandro@gmail.com>