### PR TITLE
Undefined name: log() must be imported before it is called

### DIFF
--- a/lib/bup/cmd/fuse.py
+++ b/lib/bup/cmd/fuse.py
@@ -18,6 +18,7 @@ if sys.version_info[0] > 2:
         fuse_ver = fuse.__version__.split('.')
         fuse_ver_maj = int(fuse_ver[0])
     except:
+        from bup.helpers import log
         log('error: cannot determine the fuse major version; please report',
             file=sys.stderr)
         sys.exit(2)


### PR DESCRIPTION
`log()` is imported on line 32 ___after___ it is called on line 22 which will result in a NameError being raised from the bare except with nothing logged.

$ `  flake8 . --count --select=E9,F63,F7,F82,Y --show-source --statistics`
```
./bup/lib/bup/cmd/fuse.py:21:9: F821 undefined name 'log'
        log('error: cannot determine the fuse major version; please report',
        ^
1     F821 undefined name 'log'
1
```

We discuss code changes on the mailing list bup-list@googlegroups.com,
but if you'd prefer to begin the process with a pull request, that's
just fine.  We're happy to have the help.

In any case, please make sure each commit includes a

  Signed-off-by: Someone <someone@some.where>

line in the commit message that matches the "Author" line so that
we'll be able to include your work in the project.  See
./SIGNED-OFF-BY for the meaning:

  https://github.com/bup/bup/blob/master/SIGNED-OFF-BY

After you submit the pull request, someone will eventually redirect it
to the list for review, and you will of course be included in the
conversation there.

On the other hand, if you're comfortable with "git send-email" (or the
equivalent), please post your patches to the list as described in the
"Submitting Patches" section in ./HACKING:

  https://github.com/bup/bup/blob/master/HACKING

