### PR TITLE
Add file/folder illustration of the repo format

### DIFF
--- a/DESIGN
+++ b/DESIGN
@@ -102,9 +102,12 @@ break anything.  It's also a comfort to know you can squeeze data out using
 git, just in case bup fails you, and as a developer, git offers some nice
 tools (like 'git rev-list' and 'git log' and 'git diff' and 'git show' and
 so on) that allow you to explore your repository and help debug when things
-go wrong.
+go wrong.  However, you will notice differences when you 'git checkout': 
+Large files apprear as folders, have different levels of subfolders, in which
+you find small files. Concatenate these and you restore your file, for example
+using 'find path/to/your/file.bup -type f | sort | xargs cat > output/file'.
 
-Now, bup does use these tools a little bit differently than plain git.  We
+So, bup uses the git builing blocks a little bit different than plain git. We
 need to do this in order to address two deficiencies in git when used for
 large backups, namely a) git bogs down and crashes if you give it really
 large files; b) git is too slow when you give it too many files; and c) git


### PR DESCRIPTION
This is a minor change in the DESIGN document, but it would have helped me a lot to understand the functionality of bup.
From reading "git for computer scientists" alone, I did not realize that git trees and blobs are 1-to-1 mapped to directories and files on `git checkout`. I searched for ways in how git alone can merge several blobs to one file, which it cant. The reason is this sentence:

> ... so you can use git to manipulate the bup repository if you want, and you
> probably won't break anything.  It's also a comfort to know you can squeeze
> data out using git, just in case bup fails you, and as a developer, git offers
> some nice tools ...

where I interpreted "squeeze out" as a simple "git checkout", which is not true, as bup splits files. The added text makes this more concrete and prepares the reader for the parts about hashsplitting and fanout

Signed-off-by: Moritz Lell <mlell08@gmail.com>

