### PR TITLE
cirrus: Switch FreeBSD to 14.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -48,7 +48,7 @@ task:
 task:
   name: freebsd check
   freebsd_instance:
-    image: freebsd-12-4-release-amd64
+    image: freebsd-13-2-release-amd64
     cpu: 4
     memory: 4
   script: |


### PR DESCRIPTION
12.4 is EOL at the end of 2023.  Switch to the latest supported release, which is 14.0.

