### PR TITLE
Clarify and improve formatting of examples in --exclude-rx in bup-index.1.md

### DIFF
--- a/Documentation/bup-index.1.md
+++ b/Documentation/bup-index.1.md
@@ -172,12 +172,12 @@ does, due to the accommodations described above.
     contents of /tmp, but not the directory itself, use
     "^/tmp/.". (may be repeated)
 
-    Examples:
+    Examples (the quotes are interpretted by your shell and are not part of the regex):
 
-      * '/foo$' - exclude any file named foo
-      * '/foo/$' - exclude any directory named foo
-      * '/foo/.' - exclude the content of any directory named foo
-      * '^/tmp/.' - exclude root-level /tmp's content, but not /tmp itself
+      * "/foo$"   — exclude any file named foo
+      * "/foo/$"  — exclude any directory named foo
+      * "/foo/."  — exclude the content of any directory named foo
+      * "^/tmp/." — exclude root-level /tmp's content, but not /tmp itself
 
 \--exclude-rx-from=*filename*
 :   read --exclude-rx patterns from *filename*, one pattern per-line


### PR DESCRIPTION
The single quotes used in examples are converted to a leading backtick, which is confusing. This is how it looks on my system:

<img width="774" height="343" alt="Screenshot_20260208_124638" src="https://github.com/user-attachments/assets/74f01bf6-c6f8-4e6f-a901-031dc2c9f79f" />

Other changes:

1) use m-dash instead of a hyphen, it looks better
…ex.1.md2) fix internal indentation
3) specify the role of quotes (that is something that confused me, are quotes part of the regex or not?)

